### PR TITLE
Append button to subheader

### DIFF
--- a/shilling-phabricator-tracking-issue-creator.user.js
+++ b/shilling-phabricator-tracking-issue-creator.user.js
@@ -42,5 +42,5 @@
 	button.addEventListener('click', () => {
 		window.open(githubUrl, '_blank');
 	});
-	document.querySelector('.phui-header-shell').appendChild(button);
+	document.querySelector('.phui-header-shell .phui-header-subheader').appendChild(button);
 })();


### PR DESCRIPTION
You might have already considered this, but to reduce the vertical clutter, I made a change to the script on my computer to append the button to the sub-header of the page. No pressure to merge - just figured I'd open a diff to steal contributor credit ;)

| Before      | After |
| ----------- | ----------- |
| <img width="648" alt="Screenshot 2024-03-18 at 3 04 42 PM" src="https://github.com/sirbrillig/shilling-phabricator-tracking-issue-creator/assets/942359/095b264e-31b1-467c-8c8b-bfa1c2091910"> | <img width="669" alt="Screenshot 2024-03-18 at 3 01 50 PM" src="https://github.com/sirbrillig/shilling-phabricator-tracking-issue-creator/assets/942359/a9bb3caa-8cfc-44b7-aaa7-d66b4c5360e3"> |